### PR TITLE
The change of the way the engine name content is defined in the variable.

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -248,7 +248,7 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 			) Engine=%s`, ch.config.MigrationsTable, ch.config.MigrationsTableEngine)
 	}
 
-	if strings.HasSuffix(ch.config.MigrationsTableEngine, "Tree") {
+	if strings.Contains(ch.config.MigrationsTableEngine, "MergeTree") {
 		query = fmt.Sprintf(`%s ORDER BY sequence`, query)
 	}
 


### PR DESCRIPTION
https://github.com/golang-migrate/migrate/issues/1097

